### PR TITLE
Provide shorter and more accurate suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ func main() {
 ```
 
 ```console
-go vet -vettool=(which execinquery) ./...
+go vet -vettool=$(which execinquery) ./...
 
 # command-line-arguments
-./a.go:16:11: It's better to use Execute method instead of Query method to execute `UPDATE` query
+./a.go:16:11: Use Exec instead of Query to execute `UPDATE` query
 ```
 
 ## CI
@@ -68,7 +68,7 @@ go vet -vettool=(which execinquery) ./...
   run: go vet -vettool=`which execinquery` ./...
 ```
 
-### License 
+### License
 
 MIT license.
 

--- a/execinquery.go
+++ b/execinquery.go
@@ -44,8 +44,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				return
 			}
 
-			var i int
+			replacement := "Exec"
+			var i int // the index of the query argument
 			if strings.Contains(selector.Sel.Name, "Context") {
+				replacement = "ExecContext"
 				i = 1
 			}
 
@@ -66,7 +68,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 			s = strings.ToTitle(strings.SplitN(s, " ", 2)[0])
 
-			pass.Reportf(n.Fun.Pos(), "It's better to use Execute method instead of %s method to execute `%s` query", selector.Sel.Name, s)
+			pass.Reportf(n.Fun.Pos(), "Use %s instead of %s to execute `%s` query", replacement, selector.Sel.Name, s)
 		}
 	})
 

--- a/execinquery.go
+++ b/execinquery.go
@@ -55,20 +55,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				return
 			}
 
-			s := getQueryString(n.Args[i])
-			if s == "" {
+			query := getQueryString(n.Args[i])
+			if query == "" {
 				return
 			}
 
-			s = strings.TrimSpace(cleanValue(s))
+			query = strings.TrimSpace(cleanValue(query))
+			cmd, _, _ := strings.Cut(query, " ")
+			cmd = strings.ToTitle(cmd)
 
-			if strings.HasPrefix(strings.ToLower(s), "select") {
+			if strings.HasPrefix(cmd, "SELECT") {
 				return
 			}
 
-			s = strings.ToTitle(strings.SplitN(s, " ", 2)[0])
-
-			pass.Reportf(n.Fun.Pos(), "Use %s instead of %s to execute `%s` query", replacement, selector.Sel.Name, s)
+			pass.Reportf(n.Fun.Pos(), "Use %s instead of %s to execute `%s` query", replacement, selector.Sel.Name, cmd)
 		}
 	})
 

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -18,35 +18,34 @@ func sample(db *sql.DB) {
 
 	_ = db.QueryRowContext(context.Background(), "SELECT * FROM test WHERE test=?", s)
 	_ = db.QueryRowContext(context.Background(), selectWithComment, s)
-	_ = db.QueryRowContext(context.Background(), deleteWithComment, s) // want "It\\'s better to use Execute method instead of QueryRowContext method to execute `DELETE` query"
+	_ = db.QueryRowContext(context.Background(), deleteWithComment, s) // want "Use ExecContext instead of QueryRowContext to execute `DELETE` query"
 
-	_ = db.QueryRowContext(context.Background(), "DELETE * FROM test WHERE test=?", s) // want "It\\'s better to use Execute method instead of QueryRowContext method to execute `DELETE` query"
-	_ = db.QueryRowContext(context.Background(), "UPDATE * FROM test WHERE test=?", s) // want "It\\'s better to use Execute method instead of QueryRowContext method to execute `UPDATE` query"
+	_ = db.QueryRowContext(context.Background(), "DELETE * FROM test WHERE test=?", s) // want "Use ExecContext instead of QueryRowContext to execute `DELETE` query"
+	_ = db.QueryRowContext(context.Background(), "UPDATE * FROM test WHERE test=?", s) // want "Use ExecContext instead of QueryRowContext to execute `UPDATE` query"
 
-	_, _ = db.Query("UPDATE * FROM test WHERE test=?", s)                              // want "It\\'s better to use Execute method instead of Query method to execute `UPDATE` query"
-	_, _ = db.QueryContext(context.Background(), "UPDATE * FROM test WHERE test=?", s) // want "It\\'s better to use Execute method instead of QueryContext method to execute `UPDATE` query"
-	_ = db.QueryRow("UPDATE * FROM test WHERE test=?", s)                              // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
+	_, _ = db.Query("UPDATE * FROM test WHERE test=?", s)                              // want "Use Exec instead of Query to execute `UPDATE` query"
+	_, _ = db.QueryContext(context.Background(), "UPDATE * FROM test WHERE test=?", s) // want "Use ExecContext instead of QueryContext to execute `UPDATE` query"
+	_ = db.QueryRow("UPDATE * FROM test WHERE test=?", s)                              // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
 	query := "UPDATE * FROM test where test=?"
-	_, _ = db.Query(query, s) // want "It\\'s better to use Execute method instead of Query method to execute `UPDATE` query"
+	_, _ = db.Query(query, s) // want "Use Exec instead of Query to execute `UPDATE` query"
 
-	var f1 = `
+	f1 := `
 UPDATE * FROM test WHERE test=?`
-	_ = db.QueryRow(f1, s) // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
+	_ = db.QueryRow(f1, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
 	const f2 = `
 UPDATE * FROM test WHERE test=?`
-	_ = db.QueryRow(f2, s) // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
+	_ = db.QueryRow(f2, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
 	f3 := `
 UPDATE * FROM test WHERE test=?`
-	_ = db.QueryRow(f3, s) // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
+	_ = db.QueryRow(f3, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
 	f4 := f3
-	_ = db.QueryRow(f4, s) // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
+	_ = db.QueryRow(f4, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
 	f5 := `
 UPDATE * ` + `FROM test` + ` WHERE test=?`
-	_ = db.QueryRow(f5, s) // want "It\\'s better to use Execute method instead of QueryRow method to execute `UPDATE` query"
-
+	_ = db.QueryRow(f5, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 }


### PR DESCRIPTION
This is a PR to a PR (!) because I want to avoid merge conflicts and further delay. @lufeee Closes lufeee/execinquery#11.

## Changes

### Messages

The output before this PR:
```
It's better to use Execute method instead of QueryRowContext method to execute `UPDATE` query
```
The output after this PR:
```
Use ExecContext instead of QueryRowContext to execute `UPDATE` query
```

### Internals

1. Use the dedicated strings.Cut
2. Avoid applying strings.ToLower to the whole query.

## Benefits
1. Shorter messages.
2. More accurate suggestions (there's no Execute but Exec/ExecContext).
3. Slightly more efficient string handling.